### PR TITLE
fix ui_openssl.c:410:17

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -76,6 +76,8 @@ mkdir -p "${CURRENTPATH}/bin"
 mkdir -p "${CURRENTPATH}/lib"
 
 tar zxf openssl-${VERSION}.tar.gz -C "${CURRENTPATH}/src"
+# 修正类型声明
+sed -i '' 's/static volatile intr_signal;/static volatile int intr_signal;/' "${CURRENTPATH}/src/openssl-${VERSION}/crypto/ui/ui_openssl.c"
 cd "${CURRENTPATH}/src/openssl-${VERSION}"
 
 

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -66,7 +66,7 @@ esac
 set -e
 if [ ! -e openssl-${VERSION}.tar.gz ]; then
 	echo "Downloading openssl-${VERSION}.tar.gz"
-    curl -O https://www.openssl.org/source/openssl-${VERSION}.tar.gz
+    curl -L -O https://www.openssl.org/source/openssl-${VERSION}.tar.gz
 else
 	echo "Using openssl-${VERSION}.tar.gz"
 fi

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -77,7 +77,7 @@ mkdir -p "${CURRENTPATH}/lib"
 
 tar zxf openssl-${VERSION}.tar.gz -C "${CURRENTPATH}/src"
 # 修正类型声明
-sed -i '' 's/static volatile intr_signal;/static volatile int intr_signal;/' "${CURRENTPATH}/src/openssl-${VERSION}/crypto/ui/ui_openssl.c"
+sed -i '' 's/static volatile sig_atomic_t intr_signal;/static volatile int intr_signal;/' "${CURRENTPATH}/src/openssl-${VERSION}/crypto/ui/ui_openssl.c"
 cd "${CURRENTPATH}/src/openssl-${VERSION}"
 
 


### PR DESCRIPTION
ui_openssl.c:410:17: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
static volatile intr_signal;